### PR TITLE
feat: add basic recursive functionality through -r

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "serde",
  "toml",
  "toml_edit",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ expanduser = "1.2.2"
 toml = "0.8.23"
 edit = "0.1.5"
 toml_edit = "0.22.27"
+walkdir = "2.5.0"
 
 [workspace]
 resolver = "2"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,11 +2,14 @@ use clap::error::ErrorKind;
 use clap::CommandFactory;
 use edit::get_editor;
 use fancy_regex::{Expr, NeuralMatcherFactory, RegexBuilder};
-use std::io::BufRead;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::iter;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
 use std::sync::{Arc, RwLock};
+use walkdir::WalkDir;
 
 use anyhow::{Context, Result};
 
@@ -16,6 +19,44 @@ use crate::neural_matchers::EmbedNeuralMatcherFactory;
 use crate::Args;
 use embeddings::converters::{self, Formats};
 use embeddings::ng;
+
+struct NamedReader {
+    pub name: String,
+    pub reader: Box<dyn BufRead>,
+}
+
+fn readers(path: &str, recursive: bool) -> Result<Box<dyn Iterator<Item = Result<NamedReader>>>> {
+    if path == "-" {
+        let reader: Box<dyn BufRead> = Box::new(io::stdin().lock());
+        let reader = NamedReader {
+            name: "(standard input)".to_string(),
+            reader: reader,
+        };
+        return Ok(Box::new(iter::once(Ok(reader))));
+    }
+
+    let meta = std::fs::metadata(path).with_context(|| format!("failed to access: {}", path))?;
+    if meta.is_dir() && !recursive {
+        return Err(anyhow::anyhow!("{}: Is a directory", path));
+    }
+
+    let readers = WalkDir::new(path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .map(|e| {
+            let path = e.path();
+            let file = File::open(path).with_context(|| format!("failed to open: {:?}", path))?;
+            let reader = NamedReader {
+                name: path.to_string_lossy().into_owned(),
+                reader: Box::new(BufReader::new(file)) as Box<dyn BufRead>,
+            };
+
+            Ok(reader)
+        });
+
+    Ok(Box::new(readers))
+}
 
 fn pattern_uses_neural(pattern: &str) -> Result<bool> {
     Ok(Expr::parse_tree(pattern)?.expr.contains_neural())
@@ -53,7 +94,7 @@ pub fn handle_config(config: &NgrepConfig) -> Result<()> {
     std::process::exit(1);
 }
 
-pub fn handle_match(config: &mut NgrepConfig, args: Args, reader: Box<dyn BufRead>) -> Result<()> {
+pub fn handle_match(config: &mut NgrepConfig, args: Args) -> Result<()> {
     let mut cli = Args::command();
 
     if args.pattern.is_none() {
@@ -85,22 +126,34 @@ pub fn handle_match(config: &mut NgrepConfig, args: Args, reader: Box<dyn BufRea
     let displayer = MatchDisplayer::new(
         MatchDisplayerOptions::default()
             .with_line_number(args.line_number)
-            .with_only_matching(args.only_matching),
+            .with_only_matching(args.only_matching)
+            .with_file_name(args.recursive),
     );
 
     let mut stdout = std::io::stdout().lock();
-    for (inx, line) in reader.lines().enumerate() {
-        let line = line?;
-        let captures: Vec<(usize, usize)> = neural_regex
-            .find_iter(line.as_str())
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .with_context(|| format!("Regex matching failed on line {}", inx + 1))?
-            .into_iter()
-            .map(|cap| (cap.start(), cap.end()))
-            .collect();
 
-        if !captures.is_empty() {
-            displayer.display_line(&mut stdout, inx, &line, &captures);
+    for input in readers(&args.file, args.recursive)? {
+        let input = input?;
+
+        for (inx, line) in input.reader.lines().enumerate() {
+            let line = line?;
+            let captures: Vec<(usize, usize)> = neural_regex
+                .find_iter(line.as_str())
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .with_context(|| format!("Regex matching failed on line {}", inx + 1))?
+                .into_iter()
+                .map(|cap| (cap.start(), cap.end()))
+                .collect();
+
+            if !captures.is_empty() {
+                let ret = displayer.display_line(&mut stdout, &input.name, inx, &line, &captures);
+                if let Err(e) = ret {
+                    if e.kind() == std::io::ErrorKind::BrokenPipe {
+                        std::process::exit(0);
+                    }
+                    return Err(e.into());
+                }
+            }
         }
     }
 

--- a/src/displayers.rs
+++ b/src/displayers.rs
@@ -4,7 +4,7 @@ use colored::{Color, ColoredString, Colorize};
 
 macro_rules! try_write {
     ($handle:expr, $($arg:tt)*) => {
-        write!($handle, $($arg)*).expect("Failed to write to handle")
+        write!($handle, $($arg)*)
     };
 }
 
@@ -12,6 +12,7 @@ pub struct MatchDisplayerOptions {
     colors: Option<Vec<Color>>,
     line_number: bool,
     only_matching: bool,
+    file_name: bool,
 }
 
 impl MatchDisplayerOptions {
@@ -26,6 +27,7 @@ impl MatchDisplayerOptions {
             colors: Some(vec![Self::RED]),
             line_number: false,
             only_matching: false,
+            file_name: false,
         }
     }
 
@@ -44,6 +46,11 @@ impl MatchDisplayerOptions {
         self.only_matching = only_matching;
         self
     }
+
+    pub fn with_file_name(mut self, file_name: bool) -> Self {
+        self.file_name = file_name;
+        self
+    }
 }
 
 pub struct MatchDisplayer {
@@ -58,10 +65,22 @@ impl MatchDisplayer {
     pub fn display_line<W: Write>(
         &self,
         writer: &mut W,
-        line_inx: usize,
+        name: &str,
+        inx: usize,
         line: &str,
         matches: &[(usize, usize)],
-    ) {
+    ) -> std::io::Result<()> {
+        use std::fmt::Write as _;
+
+        let mut line_prefix = String::new();
+        if self.opts.file_name {
+            let _ = write!(line_prefix, "{name}:");
+        }
+        if self.opts.line_number {
+            let inx = inx + 1;
+            let _ = write!(line_prefix, "{inx}:");
+        }
+
         let mut cursor = 0;
         for (i, match_span) in matches.iter().enumerate() {
             let (start, end) = *match_span;
@@ -72,22 +91,23 @@ impl MatchDisplayer {
                 match_ = match_.bold();
             }
 
-            if i == 0 && self.opts.line_number {
-                try_write!(writer, "{}:", line_inx + 1);
-            }
-            if !self.opts.only_matching {
-                try_write!(writer, "{}{}", &line[cursor..start], match_);
+            if self.opts.only_matching {
+                try_write!(writer, "{}{}\n", line_prefix, match_)?;
             } else {
-                try_write!(writer, "{}\n", match_);
+                if i == 0 {
+                    try_write!(writer, "{}", line_prefix)?;
+                }
+                try_write!(writer, "{}{}", &line[cursor..start], match_)?;
             }
 
             cursor = end;
         }
         if !self.opts.only_matching {
-            try_write!(writer, "{}\n", &line[cursor..]);
+            try_write!(writer, "{}\n", &line[cursor..])?;
         }
 
         writer.flush().expect("Error flushing output");
+        Ok(())
     }
 }
 
@@ -107,7 +127,9 @@ mod tests {
         let (mut out, displayer) =
             setup_displayer(MatchDisplayerOptions::default().with_line_number(true));
 
-        displayer.display_line(&mut out, 0, "hello world", &[(0, 5)]);
+        displayer
+            .display_line(&mut out, "-", 0, "hello world", &[(0, 5)])
+            .unwrap();
         assert!(String::from_utf8(out).unwrap().starts_with("1:"));
     }
 
@@ -119,7 +141,9 @@ mod tests {
                 .with_only_matching(true),
         );
 
-        displayer.display_line(&mut out, 0, "hello world", &[(0, 5)]);
+        displayer
+            .display_line(&mut out, "-", 0, "hello world", &[(0, 5)])
+            .unwrap();
         assert_eq!(String::from_utf8(out).unwrap(), "hello\n");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,9 @@ mod config;
 mod displayers;
 mod neural_matchers;
 
-use std::{
-    fs::File,
-    io::{self, BufRead, BufReader},
-    path::{Path, PathBuf},
-};
+use std::path::PathBuf;
 
-use anyhow::{Context, Error, Result};
+use anyhow::{Error, Result};
 use clap::{Parser, Subcommand};
 use commands::{handle_config, handle_import, handle_match};
 use config::NgrepConfig;
@@ -46,6 +42,10 @@ pub struct Args {
     /// Prints only the matching part of the line
     #[arg(long, short = 'o', default_value = "false")]
     only_matching: bool,
+
+    /// Recursively search subdirectories listed
+    #[arg(long, short = 'r', short_alias = 'R', default_value = "false")]
+    recursive: bool,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -72,17 +72,6 @@ enum Commands {
     Config,
 }
 
-fn reader(path: &str) -> Result<Box<dyn BufRead>> {
-    match path {
-        "-" => Ok(Box::new(io::stdin().lock())),
-        _ => {
-            let file =
-                File::open(&Path::new(path)).context(format!("failed to open: '{}'", path))?;
-            Ok(Box::new(BufReader::new(file)))
-        }
-    }
-}
-
 fn main() -> Result<(), Error> {
     let args: Args = Args::parse();
     let mut config = NgrepConfig::load_or_init(&args)?;
@@ -99,6 +88,5 @@ fn main() -> Result<(), Error> {
         };
     }
 
-    let input = reader(&args.file.clone())?;
-    handle_match(&mut config, args, input)
+    handle_match(&mut config, args)
 }


### PR DESCRIPTION
Basic support for directory traversal via [walkdir](https://crates.io/crates/walkdir).
```
> ngrep -R "~(red;0.4)" src/
src/displayers.rs:use colored::{Color, ColoredString, Colorize};
src/displayers.rs:    colors: Option<Vec<Color>>,
src/displayers.rs:    const RED: Color = Color::TrueColor {
src/displayers.rs:            colors: Some(vec![Self::RED]),
src/displayers.rs:    pub fn with_colors(mut self, colors: Option<Vec<Color>>) -> Self {
src/displayers.rs:        self.colors = colors;
src/displayers.rs:            let mut match_ = ColoredString::from(&line[start..end]);
src/displayers.rs:            if let Some(colors) = &self.opts.colors {
src/displayers.rs:                match_.fgcolor = Some(colors[i % colors.len()]);
src/displayers.rs:                .with_colors(None)
src/commands.rs:            name: "(standard input)".to_string(),
src/commands.rs:            ErrorKind::MissingRequiredArgument,
src/commands.rs:            "Missing required argument: pattern",
```